### PR TITLE
SA-8604 avoid seg fault with null URLContext with ffurl_get_file_hand…

### DIFF
--- a/libavformat/avio.c
+++ b/libavformat/avio.c
@@ -625,6 +625,8 @@ int64_t ffurl_size(URLContext *h)
 
 int ffurl_get_file_handle(URLContext *h)
 {
+    if (!h)
+        return -1;
     if (!h->prot->url_get_file_handle)
         return -1;
     return h->prot->url_get_file_handle(h);


### PR DESCRIPTION
…le() (as is the case with RTCP port failing to bind with RTP protocol

Pretty straightforward null pointer check :) could've caught it earlier in the rtpproto.c call but I figured isn't a bad thing to do so in the lower levels.