### PR TITLE
SA-9862 SA-9762 SA-8945 libavformat rtsp: fix application of 'localaddr' option...

### DIFF
--- a/libavformat/rtpproto.c
+++ b/libavformat/rtpproto.c
@@ -247,7 +247,7 @@ static void build_udp_url(RTPContext *s,
         url_add_option(buf, buf_size, "connect=1");
     if (s->dscp >= 0)
         url_add_option(buf, buf_size, "dscp=%d", s->dscp);
-    if (s->localaddr && s->localaddr)
+    if (s->localaddr && s->localaddr[0])
         url_add_option(buf, buf_size, "localaddr=%s", s->localaddr);
     url_add_option(buf, buf_size, "fifo_size=0");
     if (include_sources && include_sources[0])

--- a/libavformat/rtpproto.c
+++ b/libavformat/rtpproto.c
@@ -383,6 +383,9 @@ static int rtp_open(URLContext *h, const char *uri, int flags)
             rtp_parse_addr_list(h, s->block, &s->ssm_exclude_addrs, &s->nb_ssm_exclude_addrs);
             block = s->block;
         }
+        if (av_find_info_tag(buf, sizeof(buf), "localaddr", p)) {
+            av_opt_set(s, "localaddr", buf, 0);
+        }
     }
 
     if (s->fec_options_str) {

--- a/libavformat/rtsp.c
+++ b/libavformat/rtsp.c
@@ -124,8 +124,6 @@ static AVDictionary *map_to_opts(RTSPState *rt)
 
     snprintf(buf, sizeof(buf), "%d", rt->buffer_size);
     av_dict_set(&opts, "buffer_size", buf, 0);
-    if ( rt->localaddr )
-        av_dict_set( &opts, "localaddr", rt->localaddr, 0 );
 
     return opts;
 }
@@ -2315,6 +2313,8 @@ static int sdp_read_header(AVFormatContext *s)
 
         if (!(rt->rtsp_flags & RTSP_FLAG_CUSTOM_IO)) {
             AVDictionary *opts = map_to_opts(rt);
+            if (rt->localaddr)
+                av_dict_set(&opts, "localaddr", rt->localaddr, 0);
 
             err = getnameinfo((struct sockaddr*) &rtsp_st->sdp_ip,
                               sizeof(rtsp_st->sdp_ip),

--- a/libavformat/rtsp.c
+++ b/libavformat/rtsp.c
@@ -1621,7 +1621,7 @@ int ff_rtsp_make_setup_request(AVFormatContext *s, const char *host, int port,
                         namebuf, sizeof(namebuf), NULL, 0, NI_NUMERICHOST);
             ff_url_join(url, sizeof(url), "rtp", NULL, namebuf,
                         port, "%s", optbuf);
-            if (ffurl_open_whitelist(&rtsp_st->rtp_handle, url, AVIO_FLAG_READ_WRITE,
+            if (ffurl_open_whitelist(&rtsp_st->rtp_handle, url, AVIO_FLAG_READ,
                                      &s->interrupt_callback, &opts,
                                      s->protocol_whitelist,
                                      s->protocol_blacklist, NULL) < 0) {

--- a/libavformat/rtsp.c
+++ b/libavformat/rtsp.c
@@ -77,7 +77,7 @@
 #define COMMON_OPTS() \
     { "reorder_queue_size", "set number of packets to buffer for handling of reordered packets", OFFSET(reordering_queue_size), AV_OPT_TYPE_INT, { .i64 = -1 }, -1, INT_MAX, DEC }, \
     { "buffer_size",        "Underlying protocol send/receive buffer size",                  OFFSET(buffer_size),           AV_OPT_TYPE_INT, { .i64 = -1 }, -1, INT_MAX, DEC|ENC }, \
-    { "localaddr",          "Local address",                                                     OFFSET(localaddr),             AV_OPT_TYPE_STRING, { .str = NULL }, DEC } \
+    { "localaddr",          "Local address",                                                     OFFSET(localaddr),             AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, DEC } \
 
 
 const AVOption ff_rtsp_options[] = {
@@ -1624,7 +1624,9 @@ int ff_rtsp_make_setup_request(AVFormatContext *s, const char *host, int port,
             ff_url_join(url, sizeof(url), "rtp", NULL, namebuf,
                         port, "%s", optbuf);
             if (ffurl_open_whitelist(&rtsp_st->rtp_handle, url, AVIO_FLAG_READ_WRITE,
-                           &s->interrupt_callback, opts, s->protocol_whitelist, s->protocol_blacklist, NULL) < 0) {
+                                     &s->interrupt_callback, &opts,
+                                     s->protocol_whitelist,
+                                     s->protocol_blacklist, NULL) < 0) {
                 err = AVERROR_INVALIDDATA;
                 goto fail;
             }


### PR DESCRIPTION
… to avoid crash and support for unicast UDP transport

* [SA-9862 Fix RTSP with (unicast) UDP transport support](https://sbgsportssoftware.atlassian.net/browse/SA-9862) (see also https://sbgsportssoftware.atlassian.net/browse/DESK-502)
* [SA-9762 Crashes when connecting to RTSP streams with multicast transport (and revert SA-9795 to restore SA-8945)](https://sbgsportssoftware.atlassian.net/browse/SA-9762)
* [SA-8945 Re-connect RTP/SDP streams when an adapter is disconnected and then reconnected or when using multiple adapters](https://sbgsportssoftware.atlassian.net/browse/SA-8945)