### PR TITLE
SA-14771 fix dshow get device list when only audio devices available

### DIFF
--- a/libavdevice/dshow.c
+++ b/libavdevice/dshow.c
@@ -1279,116 +1279,6 @@ static int dshow_read_packet(AVFormatContext *s, AVPacket *pkt)
     return ctx->eof ? AVERROR(EIO) : pkt->size;
 }
 
-static int dshow_get_device_list(AVFormatContext *avctx, AVDeviceInfoList *device_list)
-{
-    IEnumMoniker *classenum = NULL;
-    ICreateDevEnum *devenum = NULL;
-    IMoniker *m = NULL;
-    int r = 0;
-    const GUID *device_guid[2] = { &CLSID_VideoInputDeviceCategory,
-                                   &CLSID_AudioInputDeviceCategory };
-
-
-    device_list->nb_devices = 0;
-    device_list->devices = NULL;
-    r = CoInitialize(0);
-    if(r != S_OK && r != S_FALSE){ // S_FALSE means already initialized
-        return AVERROR(EIO);
-    }
-
-    r = CoCreateInstance(&CLSID_SystemDeviceEnum, NULL, CLSCTX_INPROC_SERVER,
-                         &IID_ICreateDevEnum, (void **) &devenum);
-    if (r != S_OK) {
-        av_log(avctx, AV_LOG_ERROR, "Could not enumerate system devices.\n");
-        r = AVERROR(EIO);
-        goto fail2;
-    }
-
-    for(int sourcetype = 0; sourcetype<2; sourcetype++){
-        r = ICreateDevEnum_CreateClassEnumerator(devenum, device_guid[sourcetype],
-                                             (IEnumMoniker **) &classenum, 0);
-        if (r != S_OK) {
-            av_log(avctx, AV_LOG_ERROR, "Could not enumerate dshow devices (or none found).\n");
-            r = AVERROR(EIO);
-            goto fail2;
-        }
-
-        while (IEnumMoniker_Next(classenum, 1, &m, NULL) == S_OK) {
-            IPropertyBag *bag = NULL;
-            char *friendly_name = NULL;
-            char *unique_name = NULL;
-            VARIANT var;
-            VariantInit(&var);
-            IBindCtx *bind_ctx = NULL;
-            LPOLESTR olestr = NULL;
-            LPMALLOC co_malloc = NULL;
-            int i;
-
-            r = CoGetMalloc(1, &co_malloc);
-            if (r != S_OK)
-                goto fail1;
-            r = CreateBindCtx(0, &bind_ctx);
-            if (r != S_OK)
-                goto fail1;
-            /* GetDisplayname works for both video and audio, DevicePath doesn't */
-            r = IMoniker_GetDisplayName(m, bind_ctx, NULL, &olestr);
-            if (r != S_OK)
-                goto fail1;
-            unique_name = dup_wchar_to_utf8(olestr);
-            /* replace ':' with '_' since we use : to delineate between sources */
-            for (i = 0; i < strlen(unique_name); i++) {
-                if (unique_name[i] == ':')
-                    unique_name[i] = '_';
-            }
-
-            r = IMoniker_BindToStorage(m, 0, 0, &IID_IPropertyBag, (void *) &bag);
-            if (r != S_OK)
-                goto fail1;
-
-            var.vt = VT_BSTR;
-            r = IPropertyBag_Read(bag, L"FriendlyName", &var, NULL);
-            if (r != S_OK)
-                goto fail1;
-            friendly_name = dup_wchar_to_utf8(var.bstrVal);
-            char *friendly_name2 = av_malloc(strlen(friendly_name)+7);
-            strcpy(friendly_name2,sourcetype==0?"video=":"audio=");
-            strcat(friendly_name2,friendly_name);
-            av_free(friendly_name);
-
-            device_list->nb_devices +=1;
-            device_list->devices = av_realloc( device_list->devices, device_list->nb_devices * sizeof(AVDeviceInfo*));
-            
-            AVDeviceInfo* newDevice = av_malloc(sizeof(AVDeviceInfo));
-            newDevice->device_description = friendly_name2;
-            newDevice->device_name = unique_name;
-
-            device_list->devices[device_list->nb_devices - 1] = newDevice;
-    fail1:
-            VariantClear(&var);
-            if (olestr && co_malloc)
-                IMalloc_Free(co_malloc, olestr);
-            if (bind_ctx)
-                IBindCtx_Release(bind_ctx);
-            if (bag)
-                IPropertyBag_Release(bag);
-            IMoniker_Release(m);
-        }
-    }
-    
-fail2:
-    if (devenum)
-        ICreateDevEnum_Release(devenum);
-    if (classenum)
-        IEnumMoniker_Release(classenum);
-
-    CoUninitialize();
-    if (r < 0)
-    {
-        return r;
-    }
-    return device_list->nb_devices;
-}
-
 #define OFFSET(x) offsetof(struct dshow_ctx, x)
 #define DEC AV_OPT_FLAG_DECODING_PARAM
 static const AVOption options[] = {
@@ -1435,7 +1325,6 @@ AVInputFormat ff_dshow_demuxer = {
     .read_header    = dshow_read_header,
     .read_packet    = dshow_read_packet,
     .read_close     = dshow_read_close,
-    .get_device_list = dshow_get_device_list,
     .flags          = AVFMT_NOFILE,
     .priv_class     = &dshow_class,
 };

--- a/libavdevice/dshow.c
+++ b/libavdevice/dshow.c
@@ -202,11 +202,14 @@ fail:
  * retrieve the device with type specified by devtype and return the
  * pointer to the object found in *pfilter.
  * If pfilter is NULL, list all device names.
+ * If device_list is not NULL, populate it with found devices instead of
+ * outputting device names to log
  */
 static int
 dshow_cycle_devices(AVFormatContext *avctx, ICreateDevEnum *devenum,
                     enum dshowDeviceType devtype, enum dshowSourceFilterType sourcetype,
-                    IBaseFilter **pfilter, char **device_unique_name)
+                    IBaseFilter **pfilter, char **device_unique_name,
+                    AVDeviceInfoList **device_list)
 {
     struct dshow_ctx *ctx = avctx->priv_data;
     IBaseFilter *device_filter = NULL;
@@ -238,18 +241,19 @@ dshow_cycle_devices(AVFormatContext *avctx, ICreateDevEnum *devenum,
         IBindCtx *bind_ctx = NULL;
         LPOLESTR olestr = NULL;
         LPMALLOC co_malloc = NULL;
+        AVDeviceInfo *device = NULL;
         int i;
 
         r = CoGetMalloc(1, &co_malloc);
         if (r != S_OK)
-            goto fail1;
+            goto fail;
         r = CreateBindCtx(0, &bind_ctx);
         if (r != S_OK)
-            goto fail1;
+            goto fail;
         /* GetDisplayname works for both video and audio, DevicePath doesn't */
         r = IMoniker_GetDisplayName(m, bind_ctx, NULL, &olestr);
         if (r != S_OK)
-            goto fail1;
+            goto fail;
         unique_name = dup_wchar_to_utf8(olestr);
         /* replace ':' with '_' since we use : to delineate between sources */
         for (i = 0; i < strlen(unique_name); i++) {
@@ -259,34 +263,62 @@ dshow_cycle_devices(AVFormatContext *avctx, ICreateDevEnum *devenum,
 
         r = IMoniker_BindToStorage(m, 0, 0, &IID_IPropertyBag, (void *) &bag);
         if (r != S_OK)
-            goto fail1;
+            goto fail;
 
         var.vt = VT_BSTR;
         r = IPropertyBag_Read(bag, L"FriendlyName", &var, NULL);
         if (r != S_OK)
-            goto fail1;
+            goto fail;
         friendly_name = dup_wchar_to_utf8(var.bstrVal);
 
         if (pfilter) {
             if (strcmp(device_name, friendly_name) && strcmp(device_name, unique_name))
-                goto fail1;
+                goto fail;
 
             if (!skip--) {
                 r = IMoniker_BindToObject(m, 0, 0, &IID_IBaseFilter, (void *) &device_filter);
                 if (r != S_OK) {
                     av_log(avctx, AV_LOG_ERROR, "Unable to BindToObject for %s\n", device_name);
-                    goto fail1;
+                    goto fail;
                 }
                 *device_unique_name = unique_name;
                 // success, loop will end now
             }
         } else {
-            av_log(avctx, AV_LOG_INFO, " \"%s\"\n", friendly_name);
-            av_log(avctx, AV_LOG_INFO, "    Alternative name \"%s\"\n", unique_name);
+            if (device_list) {
+                device = av_mallocz(sizeof(AVDeviceInfo));
+                if (!device)
+                    goto fail;
+
+                device->device_name = av_strdup(friendly_name);
+                device->device_description = av_strdup(unique_name);
+                if (!device->device_name || !device->device_description)
+                    goto fail;
+
+                // make space in device_list for this new device
+                if (av_reallocp_array(&(*device_list)->devices,
+                                     (*device_list)->nb_devices + 1,
+                                     sizeof(*(*device_list)->devices)) < 0)
+                    goto fail;
+
+                // store device in list
+                (*device_list)->devices[(*device_list)->nb_devices] = device;
+                (*device_list)->nb_devices++;
+                device = NULL;  // copied into array, make sure not freed below
+            }
+            else {
+                av_log(avctx, AV_LOG_INFO, " \"%s\"\n", friendly_name);
+                av_log(avctx, AV_LOG_INFO, "    Alternative name \"%s\"\n", unique_name);
             av_free(unique_name);
+            }
         }
 
-fail1:
+fail:
+        if (device) {
+            av_freep(&device->device_name);
+            av_freep(&device->device_description);
+            av_free(device);
+        }
         if (olestr && co_malloc)
             IMalloc_Free(co_malloc, olestr);
         if (bind_ctx)
@@ -309,6 +341,39 @@ fail1:
     }
 
     return 0;
+}
+
+static int dshow_get_device_list(AVFormatContext *avctx, AVDeviceInfoList *device_list)
+{
+    struct dshow_ctx *ctx = avctx->priv_data;
+    ICreateDevEnum *devenum = NULL;
+    int r;
+    int ret = AVERROR(EIO);
+
+    if (!device_list)
+        return AVERROR(EINVAL);
+
+    CoInitialize(0);
+
+    r = CoCreateInstance(&CLSID_SystemDeviceEnum, NULL, CLSCTX_INPROC_SERVER,
+        &IID_ICreateDevEnum, (void**)&devenum);
+    if (r != S_OK) {
+        av_log(avctx, AV_LOG_ERROR, "Could not enumerate system devices.\n");
+        goto error;
+    }
+
+    ret = dshow_cycle_devices(avctx, devenum, VideoDevice, VideoSourceDevice, NULL, NULL, &device_list);
+    if (ret < S_OK)
+        goto error;
+    ret = dshow_cycle_devices(avctx, devenum, AudioDevice, AudioSourceDevice, NULL, NULL, &device_list);
+
+error:
+    if (devenum)
+        ICreateDevEnum_Release(devenum);
+
+    CoUninitialize();
+
+    return ret;
 }
 
 /**
@@ -712,7 +777,7 @@ dshow_list_device_options(AVFormatContext *avctx, ICreateDevEnum *devenum,
     char *device_unique_name = NULL;
     int r;
 
-    if ((r = dshow_cycle_devices(avctx, devenum, devtype, sourcetype, &device_filter, &device_unique_name)) < 0)
+    if ((r = dshow_cycle_devices(avctx, devenum, devtype, sourcetype, &device_filter, &device_unique_name, NULL)) < 0)
         return r;
     ctx->device_filter[devtype] = device_filter;
     if ((r = dshow_cycle_pins(avctx, devtype, sourcetype, device_filter, NULL)) < 0)
@@ -772,7 +837,7 @@ dshow_open_device(AVFormatContext *avctx, ICreateDevEnum *devenum,
         av_log(avctx, AV_LOG_INFO, "Capture filter loaded successfully from file \"%s\".\n", filename);
     } else {
 
-        if ((r = dshow_cycle_devices(avctx, devenum, devtype, sourcetype, &device_filter, &device_filter_unique_name)) < 0) {
+        if ((r = dshow_cycle_devices(avctx, devenum, devtype, sourcetype, &device_filter, &device_filter_unique_name, NULL)) < 0) {
             ret = r;
             goto error;
         }
@@ -1120,9 +1185,9 @@ static int dshow_read_header(AVFormatContext *avctx)
 
     if (ctx->list_devices) {
         av_log(avctx, AV_LOG_INFO, "DirectShow video devices (some may be both video and audio devices)\n");
-        dshow_cycle_devices(avctx, devenum, VideoDevice, VideoSourceDevice, NULL, NULL);
+        dshow_cycle_devices(avctx, devenum, VideoDevice, VideoSourceDevice, NULL, NULL, NULL);
         av_log(avctx, AV_LOG_INFO, "DirectShow audio devices\n");
-        dshow_cycle_devices(avctx, devenum, AudioDevice, AudioSourceDevice, NULL, NULL);
+        dshow_cycle_devices(avctx, devenum, AudioDevice, AudioSourceDevice, NULL, NULL, NULL);
         ret = AVERROR_EXIT;
         goto error;
     }
@@ -1325,6 +1390,7 @@ AVInputFormat ff_dshow_demuxer = {
     .read_header    = dshow_read_header,
     .read_packet    = dshow_read_packet,
     .read_close     = dshow_read_close,
+    .get_device_list= dshow_get_device_list,
     .flags          = AVFMT_NOFILE,
     .priv_class     = &dshow_class,
 };


### PR DESCRIPTION
https://sbgsportssoftware.atlassian.net/browse/SA-14771

- Revert "add dshow_get_device_list"
- avdevice/dshow: implement get_device_list **(cherry-pick of upstream change https://github.com/SBGSports/FFmpeg/commit/ec579b4e3609d958a4c7fcec2db85b37243f318f)**
