### PR TITLE
FOC-2155 fix HLS muxing memleak

### DIFF
--- a/libavformat/hlsenc.c
+++ b/libavformat/hlsenc.c
@@ -1418,14 +1418,13 @@ static int hls_write_packet(AVFormatContext *s, AVPacket *pkt)
             sls_flag_file_rename(hls, old_filename);
             ret = hls_start(s);
         }
+        av_free(old_filename);
 
         if (ret < 0) {
-            av_free(old_filename);
             return ret;
         }
 
         if ((ret = hls_window(s, 0)) < 0) {
-            av_free(old_filename);
             return ret;
         }
     }


### PR DESCRIPTION
https://catapult-catalyst.atlassian.net/browse/FOC-2155

~~Branched off https://github.com/SBGSports/FFmpeg/pull/12 to pre-empt binary merge conflicts in SBGSource~~

- avformat/hlsenc: move old_filename free operation earlier

Binaries of this are in https://github.com/SBGSports/SBGSource/pull/9708