### PR TITLE
Fix 32 bit builds windows

### DIFF
--- a/libavcodec/x86/cabac.h
+++ b/libavcodec/x86/cabac.h
@@ -175,8 +175,13 @@
 
 #if HAVE_7REGS && !BROKEN_COMPILER
 #define get_cabac_inline get_cabac_inline_x86
-static av_always_inline int get_cabac_inline_x86(CABACContext *c,
-                                                 uint8_t *const state)
+static
+#if defined(_WIN32) && !defined(_WIN64) && defined(__clang__)
+av_noinline
+#else
+av_always_inline
+#endif
+int get_cabac_inline_x86(CABACContext *c, uint8_t *const state)
 {
     int bit, tmp;
 #ifdef BROKEN_RELOCATIONS

--- a/libavcodec/x86/cabac.h
+++ b/libavcodec/x86/cabac.h
@@ -176,7 +176,7 @@
 #if HAVE_7REGS && !BROKEN_COMPILER
 #define get_cabac_inline get_cabac_inline_x86
 static
-#if defined(_WIN32) && !defined(_WIN64) && defined(__clang__)
+#if ARCH_X86_32
 av_noinline
 #else
 av_always_inline


### PR DESCRIPTION
Fixes 32 bit builds of FFMPEG using clang / gcc by disabling inlining in cabac.h.

See the following for more detail:
https://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=8990c5869e27fcd43b53045f87ba251f42e7d293
https://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=182663a58a7a099e02e76da3b0f96d63e5c26a6d
